### PR TITLE
(WIP) Add support for OSX build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /nbproject/private
 /build/
 /dist/
+PanelPop.app/

--- a/AI/BoardScanner.h
+++ b/AI/BoardScanner.h
@@ -1,5 +1,5 @@
 
-/* 
+/*
  * File:   BoardScanner.h
  * Author: axel
  *
@@ -10,6 +10,7 @@
 #define BOARDSCANNER_H
 
 #include <map>
+#include <array>
 #include "../Game/Board.h"
 #include"MoveActions.h"
 
@@ -58,4 +59,3 @@ private:
 };
 
 #endif /* BOARDSCANNER_H */
-

--- a/Config/ConfigHandler.h
+++ b/Config/ConfigHandler.h
@@ -17,8 +17,8 @@ public:
 
 	static ConfigHandler& getInstance();
 
-	static constexpr const char* CONFIG_FILENAME = "panelpop.ini";
-	static constexpr const KeyConfig DEFAULT_KEYS = {
+	const char* CONFIG_FILENAME = "~/Library/Application Support/panel-pop/.panelpop";
+	const KeyConfig DEFAULT_KEYS = {
 			SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT,
 			SDL_SCANCODE_RIGHT, SDL_SCANCODE_X, SDL_SCANCODE_Z };
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #
-#  There exist several targets which are by default empty and which can be 
-#  used for execution of your targets. These targets are usually executed 
-#  before and after some main targets. They are: 
+#  There exist several targets which are by default empty and which can be
+#  used for execution of your targets. These targets are usually executed
+#  before and after some main targets. They are:
 #
 #     .build-pre:              called before 'build' target
 #     .build-post:             called after 'build' target
@@ -17,13 +17,13 @@
 #  Targets beginning with '.' are not intended to be called on their own.
 #
 #  Main targets can be executed directly, and they are:
-#  
+#
 #     build                    build a specific configuration
 #     clean                    remove built files from a configuration
 #     clobber                  remove all built files
 #     all                      build all configurations
 #     help                     print help mesage
-#  
+#
 #  Targets .build-impl, .clean-impl, .clobber-impl, .all-impl, and
 #  .help-impl are implemented in nbproject/makefile-impl.mk.
 #
@@ -44,11 +44,10 @@
 # NOCDDL
 
 
-# Environment 
+# Environment
 MKDIR=mkdir
 CP=cp
 CCADMIN=CCadmin
-
 
 # build
 build: .build-post
@@ -59,6 +58,13 @@ build: .build-post
 .build-post: .build-impl
 # Add your post 'build' code here...
 
+.PHONY: osx
+osx: build
+	mkdir -p PanelPop.app/Contents/MacOS PanelPop.app/Contents/Resources
+	cp ./dist/Debug/GNU-MacOSX/panel-pop PanelPop.app/Contents/MacOS
+	cp assets/Info.plist PanelPop.app/Contents
+	cp -r assets PanelPop.app/Contents/Resources
+	cp panelpop.ini PanelPop.app/Contents/Resources
 
 # clean
 clean: .clean-post
@@ -67,7 +73,7 @@ clean: .clean-post
 # Add your pre 'clean' code here...
 
 .clean-post: .clean-impl
-# Add your post 'clean' code here...
+	rm -rf PanelPop.app/
 
 
 # clobber

--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ Debug keys:
 Misc:
 * `Ctrl`+`F` - toggle fps diplay
 * `Alt`+`Return` - toggle fullscreen
+
+# Building (OSX)
+
+    brew install sdl2 sdl2_mixir sdl2_ttf boost

--- a/assets/Info.plist
+++ b/assets/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleGetInfoString</key>
+  <string>Panel Pop</string>
+  <key>CFBundleExecutable</key>
+  <string>panel-pop</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.hinlomedia.www</string>
+  <key>CFBundleName</key>
+  <string>Panel Pop</string>
+  <key>CFBundleIconFile</key>
+  <string></string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.01</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>IFMajorVersion</key>
+  <integer>0</integer>
+  <key>IFMinorVersion</key>
+  <integer>1</integer>
+  <key>NSHighResolutionCapable</key>
+  <true />
+</dict>
+</plist>

--- a/main.cpp
+++ b/main.cpp
@@ -18,6 +18,7 @@
 #include "States/StateManager.h"
 
 int main(int argc, char* args[]) {
+	system("mkdir -p ~/Library/Application\\ Support/panel-pop; [ ! -f ~/Library/Application\\ Support/panel-pop/.panelpop ] &&  cp panelpop.ini ~/Library/Application\\ Support/panel-pop/.panelpop");
 	srand(time(NULL));
 	SDLContext& SDL = SDLContext::getInstance();
 	ConfigHandler& configHandler = ConfigHandler::getInstance();

--- a/nbproject/Makefile-Debug.mk
+++ b/nbproject/Makefile-Debug.mk
@@ -21,11 +21,12 @@ FC=gfortran
 AS=as
 
 # Macros
-CND_PLATFORM=MinGW-Windows
+CND_PLATFORM=GNU-MacOSX
 CND_DLIB_EXT=dll
 CND_CONF=Debug
 CND_DISTDIR=dist
 CND_BUILDDIR=build
+EXE_NAME=panel-pop
 
 # Include project Makefile
 include Makefile
@@ -98,9 +99,9 @@ LDLIBSOPTIONS=-lSDL2 -lSDL2_image -lSDL2_mixer -lSDL2_ttf
 
 # Build Targets
 .build-conf: ${BUILD_SUBPROJECTS}
-	"${MAKE}"  -f nbproject/Makefile-${CND_CONF}.mk ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/panel-pop.exe
+	"${MAKE}"  -f nbproject/Makefile-${CND_CONF}.mk ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/${EXE_NAME}
 
-${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/panel-pop.exe: ${OBJECTFILES}
+${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/${EXE_NAME}: ${OBJECTFILES}
 	${MKDIR} -p ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}
 	${LINK.cc} -o ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/panel-pop ${OBJECTFILES} ${LDLIBSOPTIONS}
 


### PR DESCRIPTION
Working on making an OSX build work. Making it work the ugly way first, finding out how to do it pretty later.
 
todo: 

- [ ] Don't break existing Windows build (find out how current separation of builds works, it seems one is using eclipse/netbeans generated makefiles)
- [ ] Fix music sometimes not playing (is this an existing issue or an OSX-build related issue?)
- [ ] Fix saving & loading config ini file. OSX application bundles can/should only read data within the application bundle, not write within. Configuration file should be stored in `~/Library/Application Support/MyApp/*`
 
OSX Build (as of 2018-01-04): 
[PanelPop.zip](https://github.com/a544jh/panel-pop/files/1603189/PanelPop.zip)

  